### PR TITLE
feat(lib): add logs params to return on fetchEndpoint

### DIFF
--- a/lib/AdobeConnect/createMeeting.ts
+++ b/lib/AdobeConnect/createMeeting.ts
@@ -25,9 +25,8 @@ export const createMeeting = async ({
     session: token,
     action: 'sco-shortcuts'
   })
-
-  if (getShortcutId.results.status['@_code'] === 'ok') {
-    scoId = getShortcutId.results.shortcuts.sco.find(
+  if (getShortcutId.response.results.status['@_code'] === 'ok') {
+    scoId = getShortcutId.response.results.shortcuts.sco.find(
       short => short['@_type'] === 'user-meetings'
     )['@_sco-id']
   }
@@ -43,14 +42,15 @@ export const createMeeting = async ({
     'filter-name': name
   })
   if (
-    checkMeeting.results.status['@_code'] === 'ok' &&
-    checkMeeting.results.scos.sco
+    checkMeeting.response.results.status['@_code'] === 'ok' &&
+    checkMeeting.response.results.scos.sco
   ) {
     return {
       name,
       dateInit,
-      scoId: checkMeeting.results.scos.sco['@_sco-id'],
-      url: url + checkMeeting.results.scos.sco['url-path']
+      scoId: checkMeeting.response.results.scos.sco['@_sco-id'],
+      url: url + checkMeeting.response.results.scos.sco['url-path'],
+      log: checkMeeting.log
     }
   }
 
@@ -69,18 +69,19 @@ export const createMeeting = async ({
   })
 
   if (
-    createMeeting.results.status['@_code'] !== 'ok' ||
-    !createMeeting.results.sco
+    createMeeting.response.results.status['@_code'] !== 'ok' ||
+    !createMeeting.response.results.sco
   ) {
     throw new Error(
-      'Bad response createMeeting: ' + createMeeting.results.statusText
+      'Bad response createMeeting: ' + createMeeting.response.results.statusText
     )
   }
 
   return {
     name,
     dateInit,
-    scoId: createMeeting.results.sco['@_sco-id'],
-    url: url + createMeeting.results.sco['url-path']
+    scoId: createMeeting.response.results.sco['@_sco-id'],
+    url: url + createMeeting.response.results.sco['url-path'],
+    log: createMeeting.log
   }
 }

--- a/lib/AdobeConnect/createParticipant.ts
+++ b/lib/AdobeConnect/createParticipant.ts
@@ -6,7 +6,7 @@ export const createParticipant = async (
   token: string,
   url: string
 ): Promise<Participant> => {
-  const response = await fetchEndpoint(`${url}/api/xml`, {
+  const { response, log } = await fetchEndpoint(`${url}/api/xml`, {
     session: token,
     action: 'principal-update',
     'first-name': participant.firstName,
@@ -32,7 +32,8 @@ export const createParticipant = async (
       name: principal.name,
       login: principal.login,
       email: participant.username,
-      password: participant.password
+      password: participant.password,
+      log
     }
   } else {
     /**
@@ -44,14 +45,16 @@ export const createParticipant = async (
       'filter-like-login': participant.username
     })
 
-    const principalUser = getCreatedUser.results['principal-list'].principal
+    const principalUser =
+      getCreatedUser.response.results['principal-list'].principal
     return {
       principalId: principalUser['@_principal-id'],
       accountId: principalUser['@_account-id'],
       name: principalUser.name,
       login: principalUser.login,
       email: participant.username,
-      password: participant.password
+      password: participant.password,
+      log: getCreatedUser.log
     }
   }
 }

--- a/lib/AdobeConnect/lib/fetchEndpoint.ts
+++ b/lib/AdobeConnect/lib/fetchEndpoint.ts
@@ -1,13 +1,9 @@
 import { URL } from 'url'
 import util = require('util')
+import { FetchEndpoint } from '../../'
 
 import parser = require('fast-xml-parser')
 import fetch = require('node-fetch')
-
-type ResultsEndpoint = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  results: any
-}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const fetchEndpoint = async (
@@ -15,7 +11,7 @@ export const fetchEndpoint = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any,
   debug = false
-): Promise<ResultsEndpoint> => {
+): Promise<FetchEndpoint> => {
   const endPointUrl = new URL(url)
   Object.keys(params).forEach(key =>
     endPointUrl.searchParams.append(key, params[`${key}`])
@@ -43,5 +39,13 @@ export const fetchEndpoint = async (
   if (!parsed.results) {
     throw new Error(`Fetch error on ${url} when tried action ${params?.action}`)
   }
-  return parsed
+  return {
+    response: parsed,
+    log: {
+      headers: response.headers,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url
+    }
+  }
 }

--- a/lib/AdobeConnect/participantToMeeting.ts
+++ b/lib/AdobeConnect/participantToMeeting.ts
@@ -5,7 +5,7 @@ export const participantToMeeting = async (
   props: ParticipantToMeetingProps
 ): Promise<boolean> => {
   const { scoId, principalId, permissionId, token, url } = props
-  const added = await fetchEndpoint(`${url}/api/xml`, {
+  const { response } = await fetchEndpoint(`${url}/api/xml`, {
     session: token,
     action: 'permissions-update',
     'acl-id': scoId,
@@ -13,5 +13,5 @@ export const participantToMeeting = async (
     'permission-id': permissionId
   })
 
-  return added.results.status['@_code'] === 'ok'
+  return response.results.status['@_code'] === 'ok'
 }

--- a/lib/Zoom/createMeeting.ts
+++ b/lib/Zoom/createMeeting.ts
@@ -34,7 +34,7 @@ export const createMeeting = async (meeting: Meeting): Promise<Meeting> => {
     settings
   }
 
-  const created = await fetchEndpoint({
+  const { response, log } = await fetchEndpoint({
     token,
     method: 'post',
     pathUrl: `/users/${userId}/meetings`,
@@ -42,7 +42,8 @@ export const createMeeting = async (meeting: Meeting): Promise<Meeting> => {
   })
 
   return {
-    ...created,
-    startUrl: created.start_url
+    ...response,
+    startUrl: response.start_url,
+    log
   }
 }

--- a/lib/Zoom/createParticipant.ts
+++ b/lib/Zoom/createParticipant.ts
@@ -21,23 +21,30 @@ const findOrCreate = async (
     }
   })
 
-  if (newParticipant.id) {
+  if (newParticipant.response.id) {
     const {
       id,
       first_name: firstName,
       last_name: lastName,
       email,
       type
-    } = newParticipant
+    } = newParticipant.response
     return {
       id,
       firstName,
       lastName,
       email,
       type,
-      groupId: undefined
+      groupId: undefined,
+      log: newParticipant.log
     }
   }
+
+  const oldParticipant = await fetchEndpoint({
+    token,
+    method: 'get',
+    pathUrl: `/users/${participant.email}`
+  })
 
   const {
     id,
@@ -46,11 +53,7 @@ const findOrCreate = async (
     email,
     type,
     group_ids: [groupId]
-  } = await fetchEndpoint({
-    token,
-    method: 'get',
-    pathUrl: `/users/${participant.email}`
-  })
+  } = oldParticipant.response
 
   return {
     id,
@@ -58,7 +61,8 @@ const findOrCreate = async (
     lastName,
     email,
     type,
-    groupId
+    groupId,
+    log: oldParticipant.log
   }
 }
 

--- a/lib/Zoom/goMeeting.ts
+++ b/lib/Zoom/goMeeting.ts
@@ -10,7 +10,7 @@ import { GoMeetingProps } from '..'
 export const goMeeting = async (props: GoMeetingProps): Promise<string> => {
   const { token, meetingId, email } = props
 
-  const searchRegistrants = await fetchEndpoint({
+  const { response } = await fetchEndpoint({
     token,
     method: 'get',
     pathUrl: `/meetings/${meetingId}/registrants`
@@ -19,8 +19,6 @@ export const goMeeting = async (props: GoMeetingProps): Promise<string> => {
   /**
    * @todo Pagination.
    */
-  const registrant = searchRegistrants.registrants.find(
-    record => record.email === email
-  )
+  const registrant = response.registrants.find(record => record.email === email)
   return registrant.join_url
 }

--- a/lib/Zoom/goMeetingTeacher.ts
+++ b/lib/Zoom/goMeetingTeacher.ts
@@ -11,11 +11,11 @@ export const goMeetingTeacher = async (
   props: GoMeetingProps
 ): Promise<string> => {
   const { token, meetingId } = props
-  const meeting = await fetchEndpoint({
+  const { response } = await fetchEndpoint({
     token,
     method: 'get',
     pathUrl: `/meetings/${meetingId}`
   })
 
-  return meeting.start_url
+  return response.start_url
 }

--- a/lib/Zoom/lib/fetchEndpoint.ts
+++ b/lib/Zoom/lib/fetchEndpoint.ts
@@ -1,12 +1,13 @@
 import { URL } from 'url'
 import { RequestTokenProps } from '../../types'
+import { FetchEndpoint } from '../../'
 import fetch = require('node-fetch')
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const fetchEndpoint = async (
   { token, method, pathUrl, queryUrl, body }: RequestTokenProps,
   debug = false
-): Promise<any> => {
+): Promise<FetchEndpoint> => {
   const baseUrl = 'https://api.zoom.us/'
   const endPointUrl = new URL(`/v2${pathUrl}`, baseUrl)
   if (queryUrl) {
@@ -30,5 +31,13 @@ export const fetchEndpoint = async (
   if (!response) {
     throw new Error(`Network Error on fetch ${endPointUrl}`)
   }
-  return responseText
+  return {
+    response: responseText,
+    log: {
+      headers: response.headers,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url
+    }
+  }
 }

--- a/lib/Zoom/login.ts
+++ b/lib/Zoom/login.ts
@@ -25,12 +25,12 @@ export const login = async (
   }
   const token = jwt.sign(payload, password)
   /** Obtener id de usuario para peticiones */
-  const getUserInfo = await fetchEndpoint({
+  const { response } = await fetchEndpoint({
     token,
     method: 'get',
     pathUrl: '/users/' + email
   })
-  const userId = `${getUserInfo.id}`
+  const userId = `${response.id}`
   return {
     token,
     userId

--- a/lib/Zoom/participantToMeeting.ts
+++ b/lib/Zoom/participantToMeeting.ts
@@ -6,7 +6,7 @@ export const participantToMeeting = async (
 ): Promise<boolean> => {
   const { meeting, participant, token } = props
 
-  const added = await fetchEndpoint({
+  const { response } = await fetchEndpoint({
     token,
     method: 'post',
     pathUrl: `/meetings/${meeting.id}/registrants`,
@@ -16,5 +16,5 @@ export const participantToMeeting = async (
     }
   })
 
-  return !!added
+  return !!response
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,6 +8,30 @@ export * from './Zoom/'
 export * from './BaseProvider'
 
 /**
+ * Instancia de log de una petición realizada.
+ */
+type Log = {
+  /**
+   * Cabeceras de la petición.
+   */
+  headers?: {
+    [key: string]: string | number | boolean | Date
+  }
+  /**
+   * Código de estado de la petición.
+   */
+  status?: number
+  /**
+   * Texto de estado de la petición
+   */
+  statusText?: string
+  /**
+   * Url donde se realizó la petición
+   */
+  url?: string
+}
+
+/**
  * Instancia de Meeting del Proveedor CEV.
  */
 export type Meeting = {
@@ -108,6 +132,10 @@ export type Meeting = {
    * @requires Zoom
    */
   startUrl?: string
+  /**
+   * Información de la petición para registrar en logs.
+   */
+  log?: Log
 }
 
 /**
@@ -167,6 +195,10 @@ export type Participant = {
    * Identificador del grupo al que puede pertenecer un participante.
    */
   groupId?: string
+  /**
+   * Información de la petición para registrar en logs
+   */
+  log?: Log
 }
 
 /**
@@ -257,4 +289,15 @@ export type GoMeetingProps = {
    * @requires Zoom
    */
   email?: string
+}
+
+export type FetchEndpoint = {
+  /**
+   * JSON con body de la petición.
+   */
+  response?: any
+  /**
+   * Información de la petición para registrar en logs.
+   */
+  log: Log
 }


### PR DESCRIPTION
Añadimos el apartado `log` al return de la función `fetchEndpoint` de ambas librerías (Zoom y AdobeConnect).

Este nuevo parámetro retornado posee la siguiente estructura:

``` typescript
/**
 * Instancia de log de una petición realizada.
 */
type Log = {
  /**
   * Cabeceras de la petición.
   */
  headers?: any
  /**
   * Código de estado de la petición.
   */
  status?: number
  /**
   * Texto de estado de la petición
   */
  statusText?: string
  /**
   * Url donde se realizó la petición
   */
  url?: string
} 
```

Esta información siempre será devuelta en las funciones `createMeeting` y `createParticipant` de ambos proveedores para la evaluación de peticiones restantes y registro de logs.

Ambos proveedores fueron probados testeando sus métodos `login`, `createMeeting`, `createParticipant`, `participantToMeeting` y `goMeeting`.



