### PR TITLE
feat(lib): add timeout abort controller on fetch

### DIFF
--- a/lib/AdobeConnect/createMeeting.ts
+++ b/lib/AdobeConnect/createMeeting.ts
@@ -21,67 +21,81 @@ export const createMeeting = async ({
   /**
    * Obtener `sco_id`.
    */
-  const getShortcutId = await fetchEndpoint(`${url}/api/xml`, {
-    session: token,
-    action: 'sco-shortcuts'
-  })
-  if (getShortcutId.response.results.status['@_code'] === 'ok') {
-    scoId = getShortcutId.response.results.shortcuts.sco.find(
-      short => short['@_type'] === 'user-meetings'
-    )['@_sco-id']
+  try {
+    const getShortcutId = await fetchEndpoint(`${url}/api/xml`, {
+      session: token,
+      action: 'sco-shortcuts'
+    })
+
+    if (getShortcutId.response.results.status['@_code'] === 'ok') {
+      scoId = getShortcutId.response.results.shortcuts.sco.find(
+        short => short['@_type'] === 'user-meetings'
+      )['@_sco-id']
+    }
+  } catch (err) {
+    throw new Error(err)
   }
 
   /**
    * Validar si meeting ya existe.
    */
-  const checkMeeting = await fetchEndpoint(`${url}/api/xml`, {
-    session: token,
-    action: 'sco-contents',
-    'sco-id': scoId,
-    'filter-type': 'meeting',
-    'filter-name': name
-  })
-  if (
-    checkMeeting.response.results.status['@_code'] === 'ok' &&
-    checkMeeting.response.results.scos.sco
-  ) {
-    return {
-      name,
-      dateInit,
-      scoId: checkMeeting.response.results.scos.sco['@_sco-id'],
-      url: url + checkMeeting.response.results.scos.sco['url-path'],
-      log: checkMeeting.log
+  try {
+    const checkMeeting = await fetchEndpoint(`${url}/api/xml`, {
+      session: token,
+      action: 'sco-contents',
+      'sco-id': scoId,
+      'filter-type': 'meeting',
+      'filter-name': name
+    })
+    if (
+      checkMeeting.response.results.status['@_code'] === 'ok' &&
+      checkMeeting.response.results.scos.sco
+    ) {
+      return {
+        name,
+        dateInit,
+        scoId: checkMeeting.response.results.scos.sco['@_sco-id'],
+        url: url + checkMeeting.response.results.scos.sco['url-path'],
+        log: checkMeeting.log
+      }
     }
+  } catch (err) {
+    throw new Error(err)
   }
 
   /**
    * Crear meeting
    */
-  const createMeeting = await fetchEndpoint(`${url}/api/xml`, {
-    session: token,
-    action: 'sco-update',
-    type: 'meeting',
-    name,
-    'url-path': name.toLowerCase().replace(/\s/g, '-'),
-    'folder-id': scoId,
-    'date-begin': dateInit,
-    'date-end': dateEnd
-  })
+  try {
+    const createMeeting = await fetchEndpoint(`${url}/api/xml`, {
+      session: token,
+      action: 'sco-update',
+      type: 'meeting',
+      name,
+      'url-path': name.toLowerCase().replace(/\s/g, '-'),
+      'folder-id': scoId,
+      'date-begin': dateInit,
+      'date-end': dateEnd
+    })
 
-  if (
-    createMeeting.response.results.status['@_code'] !== 'ok' ||
-    !createMeeting.response.results.sco
-  ) {
-    throw new Error(
-      'Bad response createMeeting: ' + createMeeting.response.results.statusText
-    )
-  }
+    if (
+      createMeeting.response.results.status['@_code'] !== 'ok' ||
+      !createMeeting.response.results.sco
+    ) {
+      throw new Error(
+        'Bad response createMeeting: ' +
+          createMeeting.response.results.statusText
+      )
+    }
 
-  return {
-    name,
-    dateInit,
-    scoId: createMeeting.response.results.sco['@_sco-id'],
-    url: url + createMeeting.response.results.sco['url-path'],
-    log: createMeeting.log
+    return {
+      name,
+      dateInit,
+      scoId: createMeeting.response.results.sco['@_sco-id'],
+      url: url + createMeeting.response.results.sco['url-path'],
+      log: createMeeting.log
+    }
+  } catch (err) {
+    throw new Error(err)
   }
 }

--- a/lib/AdobeConnect/createParticipant.ts
+++ b/lib/AdobeConnect/createParticipant.ts
@@ -6,55 +6,63 @@ export const createParticipant = async (
   token: string,
   url: string
 ): Promise<Participant> => {
-  const { response, log } = await fetchEndpoint(`${url}/api/xml`, {
-    session: token,
-    action: 'principal-update',
-    'first-name': participant.firstName,
-    'last-name': participant.lastName,
-    email: participant.username,
-    login: participant.username,
-    password: participant.password,
-    type: 'external-user',
-    'send-email': 'false',
-    'has-children': 0
-  })
-
-  const {
-    results: { status, principal }
-  } = response
-  /**
-   * `OK` significa que la cuenta fue creada.
-   */
-  if (status['@_code'] === 'ok') {
-    return {
-      principalId: principal['@_principal-id'],
-      accountId: principal['@_account-id'],
-      name: principal.name,
-      login: principal.login,
-      email: participant.username,
-      password: participant.password,
-      log
-    }
-  } else {
-    /**
-     * `invalid` significa que la cuenta ya existe.
-     */
-    const getCreatedUser = await fetchEndpoint(`${url}/api/xml`, {
+  try {
+    const { response, log } = await fetchEndpoint(`${url}/api/xml`, {
       session: token,
-      action: 'principal-list',
-      'filter-like-login': participant.username
-    })
-
-    const principalUser =
-      getCreatedUser.response.results['principal-list'].principal
-    return {
-      principalId: principalUser['@_principal-id'],
-      accountId: principalUser['@_account-id'],
-      name: principalUser.name,
-      login: principalUser.login,
+      action: 'principal-update',
+      'first-name': participant.firstName,
+      'last-name': participant.lastName,
       email: participant.username,
+      login: participant.username,
       password: participant.password,
-      log: getCreatedUser.log
+      type: 'external-user',
+      'send-email': 'false',
+      'has-children': 0
+    })
+    const {
+      results: { status, principal }
+    } = response
+
+    /**
+     * `OK` significa que la cuenta fue creada.
+     */
+    if (status['@_code'] === 'ok') {
+      return {
+        principalId: principal['@_principal-id'],
+        accountId: principal['@_account-id'],
+        name: principal.name,
+        login: principal.login,
+        email: participant.username,
+        password: participant.password,
+        log
+      }
+    } else {
+      /**
+       * `invalid` significa que la cuenta ya existe.
+       */
+      try {
+        const getCreatedUser = await fetchEndpoint(`${url}/api/xml`, {
+          session: token,
+          action: 'principal-list',
+          'filter-like-login': participant.username
+        })
+
+        const principalUser =
+          getCreatedUser.response.results['principal-list'].principal
+        return {
+          principalId: principalUser['@_principal-id'],
+          accountId: principalUser['@_account-id'],
+          name: principalUser.name,
+          login: principalUser.login,
+          email: participant.username,
+          password: participant.password,
+          log: getCreatedUser.log
+        }
+      } catch (err) {
+        throw new Error(err)
+      }
     }
+  } catch (err) {
+    throw new Error(err)
   }
 }

--- a/lib/AdobeConnect/login.ts
+++ b/lib/AdobeConnect/login.ts
@@ -24,19 +24,22 @@ export const login = async ({
   Object.keys(params).forEach(key =>
     loginUrl.searchParams.append(key, params[`${key}`])
   )
-  const response = await fetch(loginUrl)
+  try {
+    const response = await fetch(loginUrl)
+    if (!response.ok) {
+      throw new Error('Response Error')
+    }
 
-  if (!response.ok) {
-    throw new Error('Response Error')
+    const cookies = response.headers.get('set-cookie')
+    if (cookies === '' || !cookies.includes('BREEZESESSION')) {
+      throw new Error('Cookie BREEZESESSION not found in header')
+    }
+    const [[, breezeSession]] = cookies
+      .split(';')
+      .map(cookie => cookie.split('='))
+
+    return breezeSession
+  } catch (err) {
+    throw new Error(err)
   }
-
-  const cookies = response.headers.get('set-cookie')
-  if (cookies === '' || !cookies.includes('BREEZESESSION')) {
-    throw new Error('Cookie BREEZESESSION not found in header')
-  }
-
-  const [[, breezeSession]] = cookies
-    .split(';')
-    .map(cookie => cookie.split('='))
-  return breezeSession
 }

--- a/lib/AdobeConnect/participantToMeeting.ts
+++ b/lib/AdobeConnect/participantToMeeting.ts
@@ -5,13 +5,17 @@ export const participantToMeeting = async (
   props: ParticipantToMeetingProps
 ): Promise<boolean> => {
   const { scoId, principalId, permissionId, token, url } = props
-  const { response } = await fetchEndpoint(`${url}/api/xml`, {
-    session: token,
-    action: 'permissions-update',
-    'acl-id': scoId,
-    'principal-id': principalId,
-    'permission-id': permissionId
-  })
+  try {
+    const { response } = await fetchEndpoint(`${url}/api/xml`, {
+      session: token,
+      action: 'permissions-update',
+      'acl-id': scoId,
+      'principal-id': principalId,
+      'permission-id': permissionId
+    })
 
-  return response.results.status['@_code'] === 'ok'
+    return response.results.status['@_code'] === 'ok'
+  } catch (err) {
+    throw new Error(err)
+  }
 }

--- a/lib/Zoom/createMeeting.ts
+++ b/lib/Zoom/createMeeting.ts
@@ -33,17 +33,20 @@ export const createMeeting = async (meeting: Meeting): Promise<Meeting> => {
     schedule_for: scheduleFor,
     settings
   }
+  try {
+    const { response, log } = await fetchEndpoint({
+      token,
+      method: 'post',
+      pathUrl: `/users/${userId}/meetings`,
+      body: baseMeeting
+    })
 
-  const { response, log } = await fetchEndpoint({
-    token,
-    method: 'post',
-    pathUrl: `/users/${userId}/meetings`,
-    body: baseMeeting
-  })
-
-  return {
-    ...response,
-    startUrl: response.start_url,
-    log
+    return {
+      ...response,
+      startUrl: response.start_url,
+      log
+    }
+  } catch (err) {
+    throw new Error(err)
   }
 }

--- a/lib/Zoom/goMeeting.ts
+++ b/lib/Zoom/goMeeting.ts
@@ -10,15 +10,21 @@ import { GoMeetingProps } from '..'
 export const goMeeting = async (props: GoMeetingProps): Promise<string> => {
   const { token, meetingId, email } = props
 
-  const { response } = await fetchEndpoint({
-    token,
-    method: 'get',
-    pathUrl: `/meetings/${meetingId}/registrants`
-  })
+  try {
+    const { response } = await fetchEndpoint({
+      token,
+      method: 'get',
+      pathUrl: `/meetings/${meetingId}/registrants`
+    })
 
-  /**
-   * @todo Pagination.
-   */
-  const registrant = response.registrants.find(record => record.email === email)
-  return registrant.join_url
+    /**
+     * @todo Pagination.
+     */
+    const registrant = response.registrants.find(
+      record => record.email === email
+    )
+    return registrant.join_url
+  } catch (err) {
+    throw new Error(err)
+  }
 }

--- a/lib/Zoom/goMeetingTeacher.ts
+++ b/lib/Zoom/goMeetingTeacher.ts
@@ -11,11 +11,15 @@ export const goMeetingTeacher = async (
   props: GoMeetingProps
 ): Promise<string> => {
   const { token, meetingId } = props
-  const { response } = await fetchEndpoint({
-    token,
-    method: 'get',
-    pathUrl: `/meetings/${meetingId}`
-  })
+  try {
+    const { response } = await fetchEndpoint({
+      token,
+      method: 'get',
+      pathUrl: `/meetings/${meetingId}`
+    })
 
-  return response.start_url
+    return response.start_url
+  } catch (err) {
+    throw new Error(err)
+  }
 }

--- a/lib/Zoom/lib/fetchEndpoint.ts
+++ b/lib/Zoom/lib/fetchEndpoint.ts
@@ -2,12 +2,14 @@ import { URL } from 'url'
 import { RequestTokenProps } from '../../types'
 import { FetchEndpoint } from '../../'
 import fetch = require('node-fetch')
+import AbortController from 'abort-controller'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const fetchEndpoint = async (
   { token, method, pathUrl, queryUrl, body }: RequestTokenProps,
   debug = false
 ): Promise<FetchEndpoint> => {
+  const timeout = 8000
   const baseUrl = 'https://api.zoom.us/'
   const endPointUrl = new URL(`/v2${pathUrl}`, baseUrl)
   if (queryUrl) {
@@ -15,13 +17,16 @@ export const fetchEndpoint = async (
       endPointUrl.searchParams.append(key, queryUrl[`${key}`])
     )
   }
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), timeout)
   const response = await fetch(endPointUrl, {
     method,
     headers: {
       'Content-Type': 'application/json',
       Authorization: `bearer ${token}`
     },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
+    signal: controller.signal
   })
   const responseText = await response.json()
   if (debug) {
@@ -31,6 +36,7 @@ export const fetchEndpoint = async (
   if (!response) {
     throw new Error(`Network Error on fetch ${endPointUrl}`)
   }
+  clearTimeout(id)
   return {
     response: responseText,
     log: {

--- a/lib/Zoom/login.ts
+++ b/lib/Zoom/login.ts
@@ -25,14 +25,18 @@ export const login = async (
   }
   const token = jwt.sign(payload, password)
   /** Obtener id de usuario para peticiones */
-  const { response } = await fetchEndpoint({
-    token,
-    method: 'get',
-    pathUrl: '/users/' + email
-  })
-  const userId = `${response.id}`
-  return {
-    token,
-    userId
+  try {
+    const { response } = await fetchEndpoint({
+      token,
+      method: 'get',
+      pathUrl: '/users/' + email
+    })
+    const userId = `${response.id}`
+    return {
+      token,
+      userId
+    }
+  } catch (err) {
+    throw new Error(err)
   }
 }

--- a/lib/Zoom/participantToMeeting.ts
+++ b/lib/Zoom/participantToMeeting.ts
@@ -6,15 +6,19 @@ export const participantToMeeting = async (
 ): Promise<boolean> => {
   const { meeting, participant, token } = props
 
-  const { response } = await fetchEndpoint({
-    token,
-    method: 'post',
-    pathUrl: `/meetings/${meeting.id}/registrants`,
-    body: {
-      email: participant.email,
-      first_name: participant.firstName
-    }
-  })
+  try {
+    const { response } = await fetchEndpoint({
+      token,
+      method: 'post',
+      pathUrl: `/meetings/${meeting.id}/registrants`,
+      body: {
+        email: participant.email,
+        first_name: participant.firstName
+      }
+    })
 
-  return !!response
+    return !!response
+  } catch (err) {
+    throw new Error(err)
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,6 +1587,14 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
@@ -3926,6 +3934,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "execa": {
       "version": "4.0.2",
@@ -7647,8 +7660,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
             "tar": "^6.1.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
   },
   "homepage": "https://github.com/eclass/cev-providers#readme",
   "dependencies": {
-    "node-fetch": "2.6.1",
+    "abort-controller": "3.0.0",
     "fast-xml-parser": "3.19.0",
-    "jsonwebtoken": "8.5.1"
+    "jsonwebtoken": "8.5.1",
+    "node-fetch": "2.6.1"
   },
   "devDependencies": {
     "@commitlint/cli": "9.1.2",


### PR DESCRIPTION
Añadimos la librería `abort-controller` para controlar el timeout de las peticiones.

Se define un tiempo de espera límite de 8 segundos para finalizar cualquier petición saliente.

Si el tiempo de espera límite es excedido, se realiza un aborto de la petición con la librería antes mencionada`.

EN caso de existir un error de tiempo en la petición, se captura el error tipo `AbortError: The user aborted a request.`.

