### PR TITLE
fix(adobeconnect): fix return on goMeeting

### DIFF
--- a/lib/AdobeConnect/goMeeting.ts
+++ b/lib/AdobeConnect/goMeeting.ts
@@ -10,5 +10,9 @@ import { GoMeetingPayload } from '..'
 export const goMeeting = (url: string, token: string): GoMeetingPayload => {
   const returnUrl = new URL(url)
   returnUrl.searchParams.append('session', token)
-  return { url: returnUrl.href }
+  return {
+    url: returnUrl.href,
+    log: { status: 200, statusText: '', url: '' },
+    registrants: {}
+  }
 }


### PR DESCRIPTION
Igualamos el retorno del metodo `goMeeting` en el caso de uso de `AdobeConnect`.