### PR TITLE
fix(participant2meeting): corregimos error de lastName

### DIFF
--- a/lib/Zoom/participantToMeeting.ts
+++ b/lib/Zoom/participantToMeeting.ts
@@ -13,12 +13,11 @@ export const participantToMeeting = async (
       pathUrl: `/meetings/${meeting.id}/registrants`,
       body: {
         email: participant.email,
-        first_name: participant.firstName,
-        last_name: participant.lastName
+        first_name: participant.firstName || '.'
       }
     })
 
-    return !!response
+    return !!response && !!response.id
   } catch (err) {
     throw new Error(err)
   }


### PR DESCRIPTION
Corregimos el problema del `lastName` en el método `addParticipant2Meeting`.